### PR TITLE
Tweak User Agent

### DIFF
--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -66,7 +66,7 @@ std::string FormatSubVersion(const std::string& name, int nClientVersion, const 
 {
     std::string comments_str;
     if (!comments.empty()) comments_str = strprintf("(%s)", Join(comments, "; "));
-    return strprintf("/%s:%s%s/", name, FormatVersion(nClientVersion), comments_str);
+    return strprintf("/%s:%s%s/deis/", name, FormatVersion(nClientVersion), comments_str);
 }
 
 std::string CopyrightHolders(const std::string& strPrefix)


### PR DESCRIPTION
Makes Deis nodes recognizable on the P2P network.

The change is loosely based on Knots, minus the "base_name_only" setting which is specific to Knots: https://github.com/bitcoinknots/bitcoin/blob/v28.1.knots20250305/src/clientversion.cpp#L73